### PR TITLE
jq install instructions added for issue #31

### DIFF
--- a/tools/flasher/README.md
+++ b/tools/flasher/README.md
@@ -1,6 +1,6 @@
 # Air Guard ESP32 Flasher
 
-See [`flash.sh`](./flash.sh) which flashes the core MicroPython firmware and the Air Guard script files. Run it on your local machine if you have both `esptool.py` and `ampy` installed or use the included Docker environment.
+See [`flash.sh`](./flash.sh) which flashes the core MicroPython firmware and the Air Guard script files. Run it on your local machine if you have `esptool.py`, `ampy` and 'jq' installed or use the included Docker environment. If needed, use brew to add what's missing to your local environment (e.g. 'brew install jq'). 
 
 ## Flashing Locally
 


### PR DESCRIPTION
Add a note that jq is required plus instruction how to install it.
https://github.com/open-lv/air-guard/issues/31